### PR TITLE
linearize VectorAddKernel3D

### DIFF
--- a/alpaka/05_kernel.cc
+++ b/alpaka/05_kernel.cc
@@ -47,8 +47,8 @@ struct VectorAddKernel3D {
                                 T* __restrict__ out,
                                 Vec3D size) const {
     for (auto ndindex : alpaka::uniformElementsND(acc, size)) {
-      auto const linearizedIndex = alpaka::mapIdx<1u>(ndindex, size)[0u];
-      out[linearizedIndex] = in1[linearizedIndex] + in2[linearizedIndex];
+      auto const index = alpaka::mapIdx<1u>(ndindex, size)[0u];
+      out[index] = in1[index] + in2[index];
     }
   }
 };

--- a/alpaka/05_kernel.cc
+++ b/alpaka/05_kernel.cc
@@ -47,8 +47,8 @@ struct VectorAddKernel3D {
                                 T* __restrict__ out,
                                 Vec3D size) const {
     for (auto ndindex : alpaka::uniformElementsND(acc, size)) {
-      auto index = (ndindex[0] * size[1] + ndindex[1]) * size[2] + ndindex[2];
-      out[index] = in1[index] + in2[index];
+      auto const linearizedIndex = alpaka::mapIdx<1u>(ndindex, size)[0u];
+      out[linearizedIndex] = in1[linearizedIndex] + in2[linearizedIndex];
     }
   }
 };


### PR DESCRIPTION
This update refactors the VectorAddKernel3D struct to simplify and improve the index calculation logic within the kernel.
The manual multi-dimensional index computation is replaced with alpaka::mapIdx<1u>(ndindex, size)[0u] to obtain the linearized index directly.